### PR TITLE
fix: Allow to create new doc from url from root folder

### DIFF
--- a/src/frontend/apps/impress/conf/default.conf
+++ b/src/frontend/apps/impress/conf/default.conf
@@ -9,7 +9,7 @@ server {
       try_files $uri index.html $uri/ =404;
   }
 
-  location ~ "^/docs/new/[0-9a-fA-F]*/?$" {
+  location ~ "^/docs/new/.*/?$" {
       try_files $uri /docs/new/[dir_id]/index.html;
   }
 


### PR DESCRIPTION
Previous location regex needed to create new doc from url was not allowing some characters like ".". This character is present in Cozy drive root folder which has "io.cozy.files.root-dir" as id.